### PR TITLE
add manageable sdk versioning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,19 +11,18 @@ final ERROR_MESSAGE = "You have not defined an app key for the Onfido api."
 
 def apiKey = getValueFromFileOrEnv(APP_TOKEN_ENV_VAR_NAME, APP_TOKEN_FILE, APP_TOKEN_KEY, ERROR_MESSAGE)
 
-def sdkVersion = '2.0.0'
 def versionCodeNumber = 7
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion compile_sdk_version
+    buildToolsVersion build_tools_version
 
     defaultConfig {
         applicationId "com.onfido.sampleapp"
-        minSdkVersion 16
-        targetSdkVersion 25
+        minSdkVersion min_sdk_version
+        targetSdkVersion target_sdk_version
         versionCode versionCodeNumber
-        versionName "$versionCode-sdk:$sdkVersion"
+        versionName "$versionCode-sdk:$onfido_sdk_version"
         injectInStringResources(it, STRING_TOKEN_RES_KEY, apiKey)
         multiDexEnabled true
     }
@@ -46,30 +45,30 @@ repositories {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.onfido.sdk.capture:onfido-capture-sdk:$sdkVersion"
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    testCompile 'junit:junit:4.12'
+    compile "com.onfido.sdk.capture:onfido-capture-sdk:$onfido_sdk_version"
+    compile "com.android.support:appcompat-v7:$support_lib_version"
+    compile "com.android.support:design:$support_lib_version"
+    testCompile "junit:junit:$junit_version"
 
     /* Integration test dependencies
     * These dependencies are here just to test the integration of the sdk with app that has them.
     */
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile "com.github.bumptech.glide:glide:$glide_version"
 
     //this overrides the sdk play services dependency, without the app crashes, because there can only be one version of google play services
-    compile('com.google.android.gms:play-services-vision:10.0.1')
-    compile 'com.google.android.gms:play-services-gcm:10.0.1'
-    compile 'com.google.android.gms:play-services-analytics:10.0.1'
-    compile 'com.google.android.gms:play-services-analytics-impl:10.0.1'
-    compile 'com.google.android.gms:play-services-location:10.0.1'
-    compile 'com.google.android.gms:play-services-places:10.0.1'
-    compile 'com.google.android.gms:play-services-ads-lite:10.0.1'
-    compile 'com.google.firebase:firebase-invites:10.0.1'
-    compile 'com.google.firebase:firebase-messaging:10.0.1'
-    compile 'com.google.firebase:firebase-ads:10.0.1'
-    compile 'com.google.firebase:firebase-config:10.0.1'
-    compile 'com.google.firebase:firebase-appindexing:10.0.1'
+    compile("com.google.android.gms:play-services-vision:$play_services_version")
+    compile "com.google.android.gms:play-services-gcm:$play_services_version"
+    compile "com.google.android.gms:play-services-analytics:$play_services_version"
+    compile "com.google.android.gms:play-services-analytics-impl:$play_services_version"
+    compile "com.google.android.gms:play-services-location:$play_services_version"
+    compile "com.google.android.gms:play-services-places:$play_services_version"
+    compile "com.google.android.gms:play-services-ads-lite:$play_services_version"
+    compile "com.google.firebase:firebase-invites:$play_services_version"
+    compile "com.google.firebase:firebase-messaging:$play_services_version"
+    compile "com.google.firebase:firebase-ads:$play_services_version"
+    compile "com.google.firebase:firebase-config:$play_services_version"
+    compile "com.google.firebase:firebase-appindexing:$play_services_version"
     /*END OF Integration test dependencies*/
 
-    compile 'com.android.support:multidex:1.0.1'
+    compile "com.android.support:multidex:$multidex_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,38 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+
+    ext {
+        build_tools_version = "26.0.3"
+        gradle_tools_version = "3.0.1"
+
+        min_sdk_version = 16
+        compile_sdk_version = 26
+
+        target_sdk_version = compile_sdk_version
+
+        support_lib_version = "26.1.0"
+        play_services_version = "11.6.2"
+        glide_version = "3.7.0"
+
+        onfido_sdk_version = "2.0.0"
+
+        junit_version = "4.12"
+
+        test_runner_version = "1.0.1"
+        espresso_version = "3.0.1"
+        mockito_version = "2.12.0"
+
+        multidex_version = "1.0.2"
+    }
+
+
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath "com.android.tools.build:gradle:$gradle_tools_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +43,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
This changeset makes it easier to quickly switch SDK versions for all demo-app dependencies.
This makes it easier to test weird dependency combinations.